### PR TITLE
Fix argument error by scope

### DIFF
--- a/lib/favorite_methods.rb
+++ b/lib/favorite_methods.rb
@@ -3,8 +3,8 @@ module ActsAsFavable
     
     def self.included(favorite_model)
       favorite_model.extend Finders
-      favorite_model.scope :in_order, favorite_model.order('created_at ASC')
-      favorite_model.scope :recent, favorite_model.order('created_at DESC')
+      favorite_model.scope :in_order, Proc.new { favorite_model.order('created_at ASC') }
+      favorite_model.scope :recent, Proc.new { favorite_model.order('created_at DESC') }
     end
     
     module Finders

--- a/lib/generators/favorite/templates/favorite.rb
+++ b/lib/generators/favorite/templates/favorite.rb
@@ -4,7 +4,7 @@ class Favorite < ActiveRecord::Base
 
   belongs_to :favable, :polymorphic => true
 
-  default_scope :order => 'created_at ASC'
+  default_scope { order('created_at ASC') }
 
   # NOTE: Favorite belongs to a user
   belongs_to :user


### PR DESCRIPTION
In Rails 5, I met these errors.
This PR fix them.

```
ArgumentError: The scope body needs to be callable.
```

```
ArgumentError: Support for calling #default_scope without a block is removed. For example instead of `default_scope where(color: 'red')`, please use `default_scope { where(color: 'red') }`. (Alternatively you can just redefine self.default_scope.)
```